### PR TITLE
Docs Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+<!-- 
+
+Docs to add:
+- [ ] OIDC/SSO flows
+- [ ] Identity <> Application Users
+- [ ] keelconfig.yaml 
+- [ ] Authenticating generated clients
+- [ ] CLI all commands that aren't documented, including secrets
+
+-->
 <p align="center">
   <a href="https://keel.so/">
     <img alt="Keel" src="static/keel.svg" width="300" />
@@ -78,3 +88,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+

--- a/pages/actions.mdx
+++ b/pages/actions.mdx
@@ -111,7 +111,7 @@ model Book {
 
 ### Using `@where`
 
-You can use the `@where` attribute in a `get` operation to filter records. One use case for this is defining an action that returns data based on the calling identity.
+You can use the `@where` attribute in a `get` operation to filter records. One use case for this is defining an action that returns data based on the calling identity. We dive deeper into identities in the [Identity docs](/identity) but for now you can think of them as a way to identify the caller of an API. In the example below we define an action that returns the profile of the caller.
 
 ```keel
 model Profile {
@@ -153,7 +153,7 @@ As shown in the above schema, the inputs for a `create` action come after the `w
 
 ### Using `@set`
 
-You can use the `@set` attribute in a `create` operation to set fields on the newly created record. One use case for this is to set the calling identity on a field that uses the `Identity` model
+You can use the `@set` attribute in a `create` operation to set fields on the newly created record. One use case for this is to set the calling identity on a field that uses the `Identity` model.
 
 ```keel
 model Customer {
@@ -196,7 +196,7 @@ model Course {
 
 ```
 
-The `createCourse` Operation allows you create a course along with a number of linked lessons. The `course` field of the newly created `Lesson` records will be automatically set to the newly created `Course`.
+The `createCourse` action allows you create a course along with a number of linked lessons. The `course` field of the newly created `Lesson` records will be automatically set to the newly created `Course`.
 
 ### Linking to existing records
 
@@ -219,7 +219,7 @@ model Lesson {
 
 ### Validation
 
-For `create` built-in actions, Keel will validate that you are providing all required fields. Fields can be set using inputs, a `@default` attribute on the field, or a `@set` attribute. For Functions there are no restrictions on what inputs you accept, just that your functions creates and returns a single record. For more information see the [Function docs](/functions).
+For `create` built-in actions, Keel will validate that you are providing all required fields. Fields can be set using inputs, a `@default` attribute on the field, or a `@set` attribute. For functions, there are no restrictions on what inputs you accept, just that your functions creates and returns a single record. For more information see the [Function docs](/functions).
 
 ## `update`
 

--- a/pages/apis.mdx
+++ b/pages/apis.mdx
@@ -8,7 +8,7 @@ Your Keel backend exposes three types of APIs:
 
 When running Keel locally using `keel run` you can make requests to your API at `http://localhost:8000/api/${apiType}` and for deployed environments you'll find the domain on the **Overview page** in the Keel console.
 
-## Code Generation
+## Code generation
 
 We recommend using the [Keel CLI](/cli) to generate client code for your API. The CLI will generate a fully-typed TypeScript client for your API with autocompletion and type hints. It is the preferred way to interact with your Keel backend and recommended over directly calling the API endpoints.
 

--- a/pages/apis.mdx
+++ b/pages/apis.mdx
@@ -1,8 +1,20 @@
 # APIs
 
-Your Keel backend exposes three types of API - **GraphQL**, **JSON**, and **JSON-RPC**. When running Keel locally using `keel run` you can make requests to your API at `http://localhost:8000` and for deployed environments you'll find the domain on the **Overview page** in the console.
+Your Keel backend exposes three types of APIs:
 
-## GraphQL
+- **GraphQL**
+- **JSON**, and 
+- **JSON-RPC**
+
+When running Keel locally using `keel run` you can make requests to your API at `http://localhost:8000/api/${apiType}` and for deployed environments you'll find the domain on the **Overview page** in the Keel console.
+
+## Code Generation
+
+We recommend using the [Keel CLI](/cli) to generate client code for your API. The CLI will generate a fully-typed TypeScript client for your API with autocompletion and type hints. It is the preferred way to interact with your Keel backend and recommended over directly calling the API endpoints.
+
+To learn more about the generated client, visit its [documentation page](/apis/client).
+
+## GraphQL API
 
 **Endpoint:** `/api/graphql`
 
@@ -12,15 +24,15 @@ When running locally with `keel run` you can also access a [GraphiQL](https://gi
 
 [Read the GraphQL API docs](/apis/graphql)
 
-## JSON / OpenAPI
+## JSON API (OpenAPI)
 
-**Endpoint:** `/api/json/<actionName`
+**Endpoint:** `/api/json/<actionName>`
 
-[OpenAPI](https://www.openapis.org/) is an open-source specification for describing JSON APIs. It describes which endpoints are available and the data-type's of the requests and responses. There are many open source libraries for generating clients from an OpenAPI spec and you can download the OpenAPI (v3.1) definitions for your JSON API from the API Explorer in the console or from the `/api/json/openapi.json` endpoint of your Keel app.
+[OpenAPI](https://www.openapis.org/) is an open-source specification for describing JSON APIs. It describes which endpoints are available and the data-type's of the requests and responses. There are many open source libraries for generating clients from an OpenAPI spec and you can download the OpenAPI (v3.1) definitions for your JSON API from the API Explorer in the Keel console or from the `/api/json/openapi.json` endpoint of your Keel app.
 
 [Read the JSON API docs](/apis/json)
 
-## JSON-RPC
+## JSON-RPC API
 
 **Endpoint:** `/api/rpc`
 
@@ -40,7 +52,7 @@ import { Callout } from 'nextra/components'
 
 ## Authentication
 
-All API endpoints use the same JWT-based authentication. First you need to get a JWT (JSON Web Token) by calling the built-in `authenticate` action. You can then pass this JWT in the `Authorization` header on all subsequent requests.
+All API endpoints use the same [JWT](https://jwt.io) (JSON Web Token)-based authentication. First you need to get a JWT by calling the built-in `authenticate` action. You can then pass this JWT in the `Authorization` header on all subsequent requests.
 
 ``` filename="Example of authorization header"
 Authorization: Bearer <JWT token>

--- a/pages/apis/_meta.json
+++ b/pages/apis/_meta.json
@@ -1,5 +1,5 @@
 {
-  "graphql": "GraphQL",
-  "json": "JSON / OpenAPI",
-  "client": "Generated client"
+  "client": "Generated Client",
+  "graphql": "GraphQL API",
+  "json": "JSON API (OpenAPI)"
 }

--- a/pages/apis/client.mdx
+++ b/pages/apis/client.mdx
@@ -1,6 +1,6 @@
 # Generated API client
 
-As well as using the APIs directly, you can generated a typescript client for your frontend projects to easily work with your APIs with full end to end type safety
+As well as using the APIs directly, you can generated a TypeScript client for your frontend projects to easily work with your APIs with full end to end type safety
 
 
 import { Callout } from "nextra/components";
@@ -41,13 +41,15 @@ This client uses fetch so will only work in environments where fetch is availabl
 
 First, import `APIClient` from the generated file and create a new instance with the deployed url of your project (or the [localhost](http://localhost) address if running locally)
 
-**N.B.** This `baseUrl` url should include the API name path but not the protocol (e.g. json/rpc/gql)
+<Callout emoji="ℹ️" type="info">
+This `baseUrl` url should include the API name path but not the protocol (e.g. json/rpc/gql). For a local environment with `keel run`, this will be `http://localhost:8000/api`.
+</Callout>
 
 ```ts
 import { APIClient } from "../keelClient";
 
 const client = new APIClient({
-  baseUrl: "https://myproject.keelapps.xyz/web/",
+  baseUrl: process.env.API_BASE_URL, // http://localhost:8000/api
 });
 ```
 
@@ -61,7 +63,7 @@ This includes all the actions that you have specified in your Keel schema. For e
 
 ```ts
 const client = new APIClient({
-  baseUrl: "https://myproject.keelapps.xyz/web/",
+  baseUrl: process.env.API_BASE_URL, // http://localhost:8000/api
 });
 
 // use generated client to execute the action on the client-side
@@ -75,7 +77,7 @@ You can also use `.api.mutations` if you have actions that mutate data. For exam
 
 ```ts
 const client = new APIClient({
-  baseUrl: "https://myproject.keelapps.xyz/web/",
+  baseUrl: process.env.API_BASE_URL, // http://localhost:8000/api
 });
 
 // use generated client to execute the action on the client-side
@@ -105,7 +107,7 @@ This provides access to user authentication state. It includes the following opt
 **Usage:**
 ```ts
 const client = new APIClient({
-  baseUrl: "https://myproject.keelapps.xyz/web/",
+  baseUrl: process.env.API_BASE_URL, // http://localhost:8000/api
 });
 
 // returns a boolean that represents if a user is authenticated or not
@@ -116,8 +118,8 @@ client.ctx.token
 ```
 
 
-### Authenticating
-
+### Authenticating 
+{/* @todo in a separate PR redo this with the new auth*/}
 If your API requires authentication, use the `authenticate` action as normal and then store the returned token to be used for subsequent requests
 
 ```tsx

--- a/pages/events.mdx
+++ b/pages/events.mdx
@@ -4,7 +4,7 @@ Events and subscribers provide the ability to asynchronously execute code when a
 
 Keel currently supports three types of events at the model level; `create`, `update` and `delete` events. These events are fired when a model undergoes the relevant mutation; whether it be due to an action or from using the [Model API](https://docs.keel.so/functions/sdk/modelApi) in a job, hook, custom function, or even in a subscriber.
 
-These event types can be configured to execute a _subscriber_. Similar to jobs, subscribers are Typescript functions which you provide your own implementation for. This means you can write custom code to respond to events that are triggered while your application is running.
+These event types can be configured to execute a _subscriber_. Similar to jobs, subscribers are TypeScript functions which you provide your own implementation for. This means you can write custom code to respond to events that are triggered while your application is running.
 
 import { Callout } from 'nextra/components'
 
@@ -64,7 +64,7 @@ Subscriber functions receive two arguments, namely:
 - `ctx` - a context object which contains [environment variables](/envvars) and [secrets](/secrets)
 - `event` - the details of the event that occurred, including a payload of the mutated model
 
-Continuing with our example, if a `create` event type is triggered on the `Member` model, the following Typescript definition of the `event` argument in the subscriber function would be generated:
+Continuing with our example, if a `create` event type is triggered on the `Member` model, the following TypeScript definition of the `event` argument in the subscriber function would be generated:
 
 ```tsx
 export interface MemberCreatedEvent = {
@@ -96,7 +96,7 @@ The `event.target.data` property provides the full model's data to the subscribe
 
 Because a subscriber function can respond to various types of events, you will likely need a way to discriminate between these event types within the code of your function.
 
-The `event` argument is a [union type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) and the `eventName` property is a [string literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).  These bits of Typescript magic let us safely switch across the different event types.
+The `event` argument is a [union type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) and the `eventName` property is a [string literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types).  These bits of TypeScript magic let us safely switch across the different event types.
 
 Below we demonstrate this by providing an example implementation for the `verifyEmail` subscriber function.
 

--- a/pages/functions.mdx
+++ b/pages/functions.mdx
@@ -33,7 +33,7 @@ type Context = {
 };
 ```
 
-## Action Functions
+## Action functions
 
 Functions can use the same action types as actions, for example `get`, `list` and so on. To make a built-in action a function, we apply the `@function` attribute. To illustrate how functions work lets implement a simple `get` function.
 

--- a/pages/functions.mdx
+++ b/pages/functions.mdx
@@ -4,7 +4,36 @@ Functions allow you to implement actions using code, but they are so much more t
 
 We currently support TypeScript for writing functions and your function code should be located in the `functions` directory of your project, with each function in its own file named the same as the function in the schema. So if you have a function called `doTheThing` in your schema, the code for this function would be located at `functions/doTheThing.ts`.
 
-## The Basics
+Once you have described your function in your schema, you can run `keel generate` via the [CLI](/cli) to scaffold the code for your functions and put files in the right place to get you started. Then, you'd just fill in your application-specific logic in the generated file and you're good to go. 
+
+Keel supports two main types of functions:
+
+1. [Action functions](#action-functions) that are defined on existing actions like `get`, `create`, `update`, and so on. These functions **modify the default behaviour of a built-in action** by *hooking* in to the lifecycle of the action. For example, you might want to add constraints to a query before it is run, or perform custom permission logic on the returned rows after the data returns from the database.
+
+2. [Custom functions](#custom-functions) that are unrelated to any built-in action. These functions are defined using the `read` or `write` action types and allow you to define custom inputs and responses. These functions are the closest to what you might think of as an [API route in Next.js](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) as they are not tied to any built-in action. They are still deeply integrated into your app, however, and you can still use the built-in Keel types and APIs to interact with your database. You'd use this type of function to communicate with 3rd party APIs, do batch operations, or perform other custom logic.
+
+## Context
+
+All functions receive a context object as their first argument. This object is very similar to the `ctx` object that can be used in expressions in your Keel schema. It provides type-safe access to [secrets](/secrets) and [environment variables](/envvars), as well as the [identity](/identity) of the caller.
+
+```ts
+type Secrets = {
+  // populated from the secrets defined in your keelconfig.yaml
+};
+
+type Environment = {
+  // populated from the environment variables defined in your keelconfig.yaml
+};
+
+type Context = {
+  secrets: Secrets;
+  env: Environment;
+  identity?: Identity;
+  now(): Date;
+};
+```
+
+## Action Functions
 
 Functions can use the same action types as actions, for example `get`, `list` and so on. To make a built-in action a function, we apply the `@function` attribute. To illustrate how functions work lets implement a simple `get` function.
 
@@ -30,34 +59,11 @@ export default GetProduct(hooks);
 
 The `@teamkeel/sdk` package is auto-generated based on your schema and contains wrapper functions for each of your schema-defined functions. These wrapper functions ensure that your code is correctly typed without having to explicitly declare types.
 
-As you can see from this example all function hooks are optional, so even if no hooks are defined a function will still work correctly. For example, if we pass `id` in the inputs to the action, the function will query the database to find a product matching that `id` and return it.
+As you can see from this example all function hooks are optional, so even if no hooks are defined a function will still work correctly. We'll talk more about hooks in a bit, but for now they're fundamentally ways to do things around the lifecycle of the main `get` function which Keel still fully manages for you. For example, if we pass `id` in the inputs to the action, the function will query the database to find a product matching that `id` and return it.
 
-Obviously if you don't need to define any hooks then you also don't need to annotate your action with `@function`.
+### Hooks
 
-## Context
-
-All functions receive a context object as their first argument. This object is very similar to the `ctx` object that can be used in expressions in your Keel schema. It provides type-safe access to [secrets](/secrets) and [environment variables](/envvars), as well as the [identity](/identity) of the caller.
-
-```ts
-type Secrets = {
-  // populated from the secrets defined in your keelconfig.yaml
-};
-
-type Environment = {
-  // populated from the environment variables defined in your keelconfig.yaml
-};
-
-type Context = {
-  secrets: Secrets;
-  env: Environment;
-  identity?: Identity;
-  now(): Date;
-};
-```
-
-## Hooks
-
-Function hooks allow you to **modify the default behaviour of a function**, for example you might want to add constraints to a query, run custom permission logic on the returned rows, create related data, or perform other side effects.
+Action function hooks allow you to **modify the default behaviour of a function**, for example you might want to add constraints to a query, run custom permission logic on the returned rows, create related data, or perform other side effects.
 
 Each hook is described in detail below but this table shows which hooks are called for which action types.
 
@@ -68,17 +74,17 @@ Each hook is described in detail below but this table shows which hooks are call
 | `beforeWrite` | ❌      | ❌       | ✅         | ✅         | ✅         |
 | `afterWrite`  | ❌      | ❌       | ✅         | ✅         | ✅         |
 
-### `beforeQuery`
+#### `beforeQuery`
 
 The `beforeQuery` hook allows you to affect which records are being acted on. If this hook is not defined then a default query is executed based on the inputs your action accepts. This hook is passed the default query and may return a modified version of it, a new query, or database record(s).
 
-#### Arguments
+##### Arguments
 
 - `ctx` - a context object which contains things like the authenticated Identity, environment variables and secrets, and request headers
 - `inputs` - the inputs provided by the caller of your function
 - `query` - the default query that will be run
 
-#### Example: extending the default query
+##### Example: extending the default query
 
 By default, a query is generated based on the inputs your action accepts. For example, given the following schema:
 
@@ -123,7 +129,7 @@ The `listFilms` action will now always filter for records whose title ends with 
 
 You would now get back films whose title starts with "star wars" **and** ends with "phantom menace". This example shows how you can _extend_ the default query for all actions that this hook is valid for.
 
-#### Example: custom query
+##### Example: custom query
 
 If you don't want the default query behaviour at all then you can return a new query object. To illustrate this the following schema defines a `get` function called `latestRelease`:
 
@@ -171,17 +177,17 @@ export default LatestRelease({
 });
 ```
 
-### `afterQuery`
+#### `afterQuery`
 
 The `afterQuery` hook allows you to modify the response, perform custom permission checks, or perform side effects using the data returned from the query.
 
-#### Arguments
+##### Arguments
 
 - `ctx` - a context object which contains things like the authenticated Identity, environment variables and secrets, and request headers
 - `inputs` - the inputs provided by the caller of your function
 - `data` - the data that was retrieved from the database
 
-#### Example: modify the response
+##### Example: modify the response
 
 The following example shows how `afterQuery` could modify the data returned from the function.
 
@@ -199,7 +205,7 @@ export default ListPreviewProducts({
 });
 ```
 
-#### Example: custom permissions check
+##### Example: custom permissions check
 
 The `afterQuery` hook could also be used to add a custom permissions check, for example:
 
@@ -223,11 +229,11 @@ export default ListProducts({
 });
 ```
 
-### `beforeWrite`
+#### `beforeWrite`
 
 The `beforeWrite` hook allows you perform side-effects or permission checks for `create`, `update`, and `delete` function. For `create` and `update` functions this hook can also be used to modify the values that will be written to the database.
 
-#### Arguments
+##### Arguments
 
 The arguments to `beforeWrite` are slightly different depending on the action type.
 
@@ -250,7 +256,7 @@ The arguments to `beforeWrite` are slightly different depending on the action ty
 - `inputs` - the inputs provided by the caller of your function
 - `record` - the record that is going to be deleted
 
-#### Example: mutate write values
+##### Example: mutate write values
 
 The following example shows how the `beforeWrite` hook can be used to mutate the values being written to the database. Here a `summary` field is computed based on the title and the first 100 characters of the description.
 
@@ -271,7 +277,7 @@ export default CreateProduct({
 });
 ```
 
-#### Example: update based on existing values
+##### Example: update based on existing values
 
 When using this hook in an `update` function the fourth argument to the hook is the _existing_ record. The following example shows how you can use that record to update the values that will be used for the update.
 
@@ -288,7 +294,7 @@ export default IncrementCounter({
 });
 ```
 
-### `afterWrite`
+#### `afterWrite`
 
 The `afterWrite` hook allows you to perform side effects after the record has been written to the database for `create` and `update` and after the record has been deleted for `delete`. Common use cases include creating other models and performing custom permission checks.
 
@@ -304,13 +310,13 @@ import { Callout } from "nextra/components";
   _asynchronously_.
 </Callout>
 
-#### Arguments
+##### Arguments
 
 - `ctx` - a context object which contains things like the authenticated Identity, environment variables and secrets, and request headers
 - `inputs` - the inputs provided by the caller of your function
 - `data` - the record that that was created/updated/deleted
 
-#### Example: creating additional records
+##### Example: creating additional records
 
 The following example shows how you can create additional records in the database in an `afterWrite` hook.
 
@@ -328,7 +334,7 @@ export default CreateProduct({
 });
 ```
 
-#### Example: posting an update to Slack
+##### Example: posting an update to Slack
 
 In a `delete` function the third argument to the `afterWrite` hook is the record that was deleted. The following example shows how you could post a message to Slack whenever a product is deleted.
 
@@ -346,147 +352,9 @@ export default DeleteProduct({
 });
 ```
 
-## Using the database
-
-The `@teamkeel/sdk` package is generated based on your schema and contains type-safe API's for interacting with your models. These APIs are all available on the exported `models` object.
-
-See [Model API](/functions/sdk/modelApi) for full usage.
-
-### Low-level database API
-
-If you need more complex database operations you can use the [Database API](/functions/sdk/databaseApi) to write custom queries.
-
-## Using `fetch`
-
-We deploy your functions into an environment running Node.js 18.x, which means the Fetch API is available.
-
-One example of using `fetch` is to proxy API calls to a 3rd party service through your Keel APIs. This is often useful if the API you want to use requires an API key and you don't want to expose that to your frontend.
-
-The following example uses the special `Any` message type to allow any input and any response from the `doSomething` function:
-
-```keel filename="schema.keel"
-model MyThing {
-  actions {
-    read doSomething(Any) returns (Any)
-  }
-}
-```
-
-The function implementation calls the 3rd party API, pass the API token, and return its response.
-
-```tsx filename="functions/doSomething.ts"
-import { DoSomething } from "@teamkeel/sdk";
-
-export default DoSomething(async (ctx, inputs) => {
-  // make an API call to 3rd party
-  const res = await fetch("https://some-cool-api.com", {
-    method: "POST",
-    headers: {
-      // use a secret to store your API token
-      "Api-Token": ctx.secrets.API_TOKEN,
-    },
-    body: JSON.stringify({
-      some: "param",
-    }),
-  });
-
-  // return the response as JSON
-  return res.json();
-});
-```
-
-## Using Headers
-
-You can access request headers by using `ctx.headers`, which is a _read-only_ version of the `[Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers)` object, and you can set response headers by using `ctx.response.headers` which is a normal [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object.
-
-```tsx filename="functions/myFunction.ts"
-export default MyFunction((inputs, api, ctx) => {
-  // read a request header
-  const reqHeader = ctx.headers.get("X-My-Custom-Header");
-
-  // write a response header
-  ctx.response.headers.set("X-My-Other-Header", "1234");
-});
-```
-
-## HTTP Status Codes
-
-You can set the HTTP status code of the response from your function, which is useful if you want to return a redirect response from your action.
-
-import { Tab, Tabs } from "nextra-theme-docs";
-
-<Tabs items={['Function', 'Schema']}>
-  <Tab>
-```tsx filename="functions/myRedirectFunction.ts"
-import { MyRedirectFunction } from "@teamkeel/sdk"
-
-export default MyRedirectFunction((inputs, api, ctx) => {
-  // do some stuff...
-
-  // return a redirect
-  ctx.response.headers.set("Location", "https://some.url.com/");
-  ctx.response.status = 302;
-  return null;
-});
-
-````
-  </Tab>
-   <Tab>
-```keel filename="schema.keel"
-model MyModel {
-  actions {
-    write myRedirectFunction(Any) returns (Any)
-  }
-}
-````
-
-  </Tab>
-</Tabs>
-
-<Callout type="info">
-  Setting the HTTP response status code will only have an affect on your JSON
-  API endpoints, so in the above example `/json/api/myRedirectFunction` will
-  return a redirect response but using `myRedirectFuntion` via GraphQL or
-  JSON-RPC API's will not.
-</Callout>
-
-## Environment Variables and Secrets
-
-Environment variables defined in your `keelconfig.yaml` file will be available in your functions by using `ctx.env`, which is typed according to the environment variables you've defined in your config file. No more un-typed `process.env` 🎉
-
-In much the same way, any secret you define in your `keelconfig.yaml` file will be available on `ctx.secrets`, which is also typed. As secrets are sensitive values they are not set as environment variables and are only accessible by using `ctx.secrets`.
-
-As an example if we have the following `keelconfig.yaml` file
-
-```yaml filename="keelconfig.yaml"
-environment:
-  default:
-    - name: MY_ENV_VAR
-      value: "some-value"
-secrets:
-	- name: MY_SECRET
-```
-
-We could then access these in a function like so
-
-```tsx filename="functions/myFunction.ts"
-export default MyFunction(async (ctx, inputs) => {
-  ctx.env.MY_ENV_VAR; // "some-value"
-  ctx.secrets.MY_SECRET; // will be decrypted secret value
-
-  // TypeScript will catch this with the error:
-  // ts(2339) Property 'FOO' does not exist on type 'Environment'.
-  ctx.env.FOO;
-
-  // TypeScript will catch this with the error:
-  // ts(2339) Property 'FOO' does not exist on type 'Secrets'.
-  ctx.secrets.FOO;
-});
-```
-
 ## Custom functions
 
-There may be cases where you want to define a function that returns custom data or needs to receive unknown data as input. For these situations, you can use the `read` and `write` action types with **messages**.
+There may be cases where you want to define a function that returns custom data or needs to receive unknown data as input. For these situations, you can use the `read` and `write` action types with `messages`.
 
 ### Custom inputs and responses
 
@@ -509,7 +377,7 @@ model Book {
 }
 ```
 
-Actions that use the `read` or `write` type must take a message as input and use the `returns` keyword to define the response message. The following example demonstrates how to define the messages we used in the `createBooks` action.
+Actions that use the `read` or `write` type must take a `message` as input and use the `returns` keyword to define the response message. The following example demonstrates how to define the messages we used in the `createBooks` action.
 
 ```keel filename="schema.keel"
 message CreateBooksInput {
@@ -529,7 +397,7 @@ message CreateBooksResponse {
 }
 ```
 
-Messages are defined using the `message` keyword and have the same syntax as the `fields` block in a model definition. Message fields can be other messages, models, enums, or built-in Keel types.
+Messages are defined using the `message` keyword and have the same syntax as the `fields` block in a [model](/models) definition. Message fields can be other messages, models, enums, or built-in Keel types.
 
 <Callout>
   Message names must be **UpperCamelCase** and must be distinct from any model
@@ -583,3 +451,141 @@ export default CustomAction(async (ctx, input) => {
 ```
 
 By default, functions will return permission denied until `allow()` is called so `deny()` only needs to be called if you are explicitly denying access in your code after an `allow()` call.
+
+
+## Using the database
+
+The `@teamkeel/sdk` package is generated based on your schema and contains type-safe APIs for interacting with your models. These APIs are all available on the exported `models` object.
+
+See [Model API](/functions/sdk/modelApi) for full usage.
+
+### Low-level database API
+
+If you need more complex database operations you can use the [Database API](/functions/sdk/databaseApi) to write custom queries.
+
+## Using `fetch`
+
+We deploy your functions into an environment running Node.js 18.x, which means the Fetch API is available globally.
+
+One example of using `fetch` is to proxy API calls to a 3rd party service through your Keel APIs. This is often useful if the API you want to use requires an API key and you don't want to expose that to your frontend.
+
+The following example uses the special `Any` message type to allow any input and any response from the `doSomething` function:
+
+```keel filename="schema.keel"
+model MyThing {
+  actions {
+    read doSomething(Any) returns (Any)
+  }
+}
+```
+
+The function implementation calls the 3rd party API, pass the API token, and return its response.
+
+```tsx filename="functions/doSomething.ts"
+import { DoSomething } from "@teamkeel/sdk";
+
+export default DoSomething(async (ctx, inputs) => {
+  // make an API call to 3rd party
+  const res = await fetch("https://some-cool-api.com", {
+    method: "POST",
+    headers: {
+      // use a secret to store your API token
+      "Api-Token": ctx.secrets.API_TOKEN,
+    },
+    body: JSON.stringify({
+      some: "param",
+    }),
+  });
+
+  // return the response as JSON
+  return res.json();
+});
+```
+
+## Using Headers
+
+You can access request headers by using `ctx.headers`, which is a _read-only_ version of the [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object, and you can set response headers by using `ctx.response.headers` which is a normal `Headers` object.
+
+```tsx filename="functions/myFunction.ts"
+export default MyFunction((inputs, api, ctx) => {
+  // read a request header
+  const reqHeader = ctx.headers.get("X-My-Custom-Header");
+
+  // write a response header
+  ctx.response.headers.set("X-My-Other-Header", "1234");
+});
+```
+
+## HTTP Status Codes
+
+You can set the HTTP status code of the response from your function, which is useful if you want to return a redirect response from your action.
+
+import { Tab, Tabs } from "nextra-theme-docs";
+
+<Tabs items={['Function', 'Schema']}>
+  <Tab>
+```tsx filename="functions/myRedirectFunction.ts"
+import { MyRedirectFunction } from "@teamkeel/sdk"
+
+export default MyRedirectFunction((inputs, api, ctx) => {
+  // do some stuff...
+
+  // return a redirect
+  ctx.response.headers.set("Location", "https://some.url.com/");
+  ctx.response.status = 302;
+  return null;
+});
+
+````
+  </Tab>
+   <Tab>
+```keel filename="schema.keel"
+model MyModel {
+  actions {
+    write myRedirectFunction(Any) returns (Any)
+  }
+}
+````
+
+  </Tab>
+</Tabs>
+
+Setting the HTTP response status code will only have an affect on your JSON
+API endpoints, so in the above example `/json/api/myRedirectFunction` will
+return a redirect response but using `myRedirectFunction` via [GraphQL](/apis/graphql) or
+[JSON-RPC](/apis#json-rpc) APIs will not.
+
+## Environment Variables and Secrets
+
+Environment variables defined in your `keelconfig.yaml` {/* 👈 @todo in a future PR */} file will be available in your functions by using `ctx.env`, which is typed according to the environment variables you've defined in your config file. No more un-typed `process.env` 🎉
+
+In much the same way, any secret you define in your `keelconfig.yaml` file will be available on `ctx.secrets`, which is also typed. As secrets are sensitive values they are not set as environment variables and are only accessible by using `ctx.secrets`.
+
+As an example if we have the following `keelconfig.yaml` file
+
+```yaml filename="keelconfig.yaml"
+environment:
+  default:
+    - name: MY_ENV_VAR
+      value: "some-value"
+secrets:
+	- name: MY_SECRET
+```
+
+We could then access these in a function like so
+
+```tsx filename="functions/myFunction.ts"
+export default MyFunction(async (ctx, inputs) => {
+  ctx.env.MY_ENV_VAR; // "some-value"
+  ctx.secrets.MY_SECRET; // will be decrypted secret value
+
+  // TypeScript will catch this with the error:
+  // ts(2339) Property 'FOO' does not exist on type 'Environment'.
+  ctx.env.FOO;
+
+  // TypeScript will catch this with the error:
+  // ts(2339) Property 'FOO' does not exist on type 'Secrets'.
+  ctx.secrets.FOO;
+});
+```
+

--- a/pages/functions/sdk.mdx
+++ b/pages/functions/sdk.mdx
@@ -1,4 +1,4 @@
-# Typescript SDK
+# TypeScript SDK
 
 The `@teamkeel/sdk` package is generated based on your schema and contains type-safe APIs for interacting with your database as well as other utilities. This SDK is available to [functions](/functions) within Keel.
 

--- a/pages/identity.mdx
+++ b/pages/identity.mdx
@@ -38,7 +38,7 @@ model User {
 }
 ```
 
-Then in your application, after a user has authenticated, you can create an `Identity` for them and associate it with their `User` record. {/* @todo in a separate PR: We cover this in more detail in the [**authentication**](/authentication) section.*/}
+Then in your application, after a user has authenticated, you can create an `Identity` for them and associate it with their `User` record. {/* @todo in a separate PR: We cover this in more detail in the authentication section.*/}
 
 ## Usage in expressions
 

--- a/pages/identity.mdx
+++ b/pages/identity.mdx
@@ -23,7 +23,7 @@ model Customer {
 
 When using `Identity` like this you will probably want to **mark the field as unique**, so that an identity relates to a single customer.
 
-### Working with Application Users 
+### Working with application users 
 
 To use the `Identity` model for authentication, you can associate it with a `User` model. A `User` model represents a user in the context of your application, and may have additional fields such as `name`, `email`, `avatar`, etc.
 

--- a/pages/identity.mdx
+++ b/pages/identity.mdx
@@ -1,6 +1,13 @@
+import { Callout } from "nextra/components"
+
 # Identity
 
-Almost every application require authentication and for this purpose Keel comes with a built-in `Identity` model. This model represents the different **identities** that have **authenticated** with your app and includes a few actions that can be used to build authentication into your product.
+Almost every application requires authentication and for this purpose Keel comes with a built-in `Identity` model. This model represents the different **identities** that have **authenticated** with your app and includes a few actions that can be used to build authentication into your product.
+
+<Callout emoji="ℹ️" type="info">
+  The `Identity` model is intended to be a building block for further authentication logic and is not intended to be a complete authentication solution. 
+</Callout>
+
 
 ## Usage in models
 
@@ -15,6 +22,23 @@ model Customer {
 ```
 
 When using `Identity` like this you will probably want to **mark the field as unique**, so that an identity relates to a single customer.
+
+### Working with Application Users 
+
+To use the `Identity` model for authentication, you can associate it with a `User` model. A `User` model represents a user in the context of your application, and may have additional fields such as `name`, `email`, `avatar`, etc.
+
+```keel
+model User {
+  fields {
+    name String
+    email String
+    avatar String
+    identity Identity @unique
+  }
+}
+```
+
+Then in your application, after a user has authenticated, you can create an `Identity` for them and associate it with their `User` record. {/* @todo in a separate PR: We cover this in more detail in the [**authentication**](/authentication) section.*/}
 
 ## Usage in expressions
 
@@ -46,7 +70,7 @@ model Post {
 
 Note that filtering records like this is different from defining [**permissions**](/permissions).
 
-### Setting a field to the callers Identity
+### Setting a field to the caller's Identity
 
 When `Identity` is used in a model as a relationship field, you should always use `ctx.identity` to set it, rather than trying to accept it as an input (which won't work).
 

--- a/pages/jobs.mdx
+++ b/pages/jobs.mdx
@@ -1,6 +1,6 @@
 # Jobs
 
-Jobs allow you to execute tasks in the background, either manually or on a schedule. Jobs are Keel's answer to the collection of random scripts that every team ends up with and that one cron job which everyone forgets about but actually keeps the business running.
+Jobs allow you to execute tasks in the background, either manually or on a schedule as with [cron](https://en.wikipedia.org/wiki/Cron). Jobs are Keel's answer to the collection of random scripts that every team ends up with and that one cron job which everyone forgets about but actually keeps the business running.
 
 Jobs are written as normal **TypeScript functions** and have full access to your database. You can view job runs from the Keel console along with full **traces and logs** for easy debugging. You can limit who can run each job with **role-based permission rules**. Jobs can also accept inputs, making it possible to build **simple but powerful internal tools**.
 
@@ -26,7 +26,7 @@ export default EmailNewCustomerReport(async (ctx) => {
 });
 ```
 
-Your job code can do whatever you want - call 3rd party API's or use packages from npm. You can also interact with the database in the same way you would in functions, using the [APIs](/functions/sdk) available in the `@teamkeel/sdk` package.
+Your job code can do whatever you want - call 3rd party APIs or use packages from npm. You can also interact with the database in the same way you would in functions, using the [APIs](/functions/sdk) available in the `@teamkeel/sdk` package.
 
 ### Limitations
 
@@ -81,6 +81,8 @@ The table below shows examples of the human-readable form with the equivalent cr
 | `"every 2 hours from 9am to 3pm"`                    | `"0 9,11,13,15 * * *"` |
 | `"every monday at 9am"`                              | `"0 9 * * 1"`          |
 | `"every tuesday and thursday at 8am, 12pm, and 5pm"` | `"0 8,12,17 * * 2,4"`  |
+
+If you're not familiar with cron syntax you can use a tool like [crontab.guru](https://crontab.guru/) to help you build your schedule.
 
 ### Validation
 

--- a/pages/keel-auth-with-nextjs/building-the-backend.mdx
+++ b/pages/keel-auth-with-nextjs/building-the-backend.mdx
@@ -52,7 +52,7 @@ With your backend deployed on Keel, head over to the API explorer tab and grab y
 
 ### Generating the Keel Client
 
-As well as using the APIs directly in three forms, we can generate a typescript client for our frontend project so that we can easily work with your APIs with full end-to-end type safety. We can do that by running the following command in the folder where our Keel schema is present:
+As well as using the APIs directly in three forms, we can generate a TypeScript client for our frontend project so that we can easily work with your APIs with full end-to-end type safety. We can do that by running the following command in the folder where our Keel schema is present:
 
 ```bash
 keel client

--- a/pages/keel-auth-with-nextjs/building-the-frontend-with-nextjs.mdx
+++ b/pages/keel-auth-with-nextjs/building-the-frontend-with-nextjs.mdx
@@ -11,7 +11,7 @@ npx create-next-app@latest
 ```
 
 <Callout type="info" emoji="💡">
- Make sure to select typescript and app router for routing as extra options while going through the interactive install.
+ Make sure to select TypeScript and app router for routing as extra options while going through the interactive install.
 </Callout>
 
 After the application has been created, please run the following command to start the Next.js development server

--- a/pages/keel-auth-with-nextjs/creating-the-login-page.mdx
+++ b/pages/keel-auth-with-nextjs/creating-the-login-page.mdx
@@ -59,7 +59,7 @@ npm i styled-components
 npm install --save @types/styled-components
 ```
 
-The command above will install `styled-components` and type definitions for `styled-components` since we are using Typescript.
+The command above will install `styled-components` and type definitions for `styled-components` since we are using TypeScript.
 
 The next thing we need to do is to import `styled-components` in the `page.tsx` file like so:
 

--- a/pages/permissions.mdx
+++ b/pages/permissions.mdx
@@ -28,21 +28,83 @@ model MyModel {
 
 The `@permission` attribute can be used at model or action level and can be used to define row-based or role-based permission rules. It accepts three arguments: **actions**, **expression**, and **roles**.
 
-The `expression` argument is for defining row-based permissions, and the provided expression is evaluated against against **each record being acted on**.
+Here's an example of model level permission rules:
 
-The `roles` argument is for role-based permissions and lets you define a list of role names that the rule should allow. The caller must have **one of the provided roles**.
+```keel {6-10}
+model Post {
+  fields {
+    author Author
+  }
+
+  // Permissions for each row on the whole model
+  @permission(
+    expression: post.author.identity == ctx.identity,
+    actions: [update]
+  )
+}
+```
+
+### Actions
 
 The `actions` argument must be provided when the rule is defined at the model level, and is a list of action types that the rule should apply to. For action level permission rules this argument must be omitted.
+
+Here's an example of action level permission rules:
+
+```keel {8-11}
+model Post {
+  fields {
+    author Author
+  }
+
+  actions {
+    update updatePost(id) with (title)
+    // Permission nested inside the update action
+      @permission(
+        expression: post.author.identity == ctx.identity
+      )
+  }
+}
+```
+
+### Expressions
+
+The `expression` argument is for defining row-based permissions, and the provided expression is evaluated against **each record being acted on**. An expression is boolean. For example, here's an expression that checks if the authenticated user is the author of a post:
+
+```keel {7}
+model Post {
+  fields {
+    author Author
+  }
+
+  @permission(
+    expression: post.author.identity == ctx.identity,
+    actions: [update]
+  )
+}
+```
+
+Similarly, for a `list` action the expression is evaluated for **each record** in the list. For example, the following schema only allows users to list posts that they are the author of:
+
+```keel {7}
+model Post {
+  fields {
+    author Author
+  }
+
+  @permission(
+    expression: post.author.identity == ctx.identity,
+    actions: [list]
+  )
+}
+```
 
 Some key things to understand are:
 
 - There can be **many** permission rules in a model or action
 - Action-level rules **override** model-level rules
-- If **any** permission rule passes the action is allowed
+- If **any** permission rule passes, the action is allowed
 
-### Expressions
-
-If provided the `expression` argument is evaluated for every record being acted upon and it has the following in-scope identifiers:
+If provided the `expression` argument has the following in-scope identifiers:
 
 - the record, available as the **lowerCamelCase** version of the model name
 - `ctx` - contains things like the authenticated identity, environment variables & secrets
@@ -51,6 +113,8 @@ If provided the `expression` argument is evaluated for every record being acted 
 If the expression evaluates to true for **all records** being acted on then the rule passes.
 
 ### Roles
+
+The `roles` argument is for role-based permissions and lets you define a list of role names that the rule should allow. The caller must have **one of the provided roles**.
 
 Roles are defined in your schema and are applied to the **authenticated Identity** based on either a specific email address or an email domain name. For example the following schema says that anyone with a `@mycorp.com` email address has the `Staff` role but only `bob@mycorp.com` and `sue@mycorp.com` have the `Developer` role.
 
@@ -232,7 +296,7 @@ This schema has a many-to-many relationship between users and projects, represen
 - From **each** `UserProject` go to the `User`
 - From **each** `User` get the `identity` field
 
-The important thing here is the **“for each”** part of the last two steps. Because a project has many users we ultimately end up with a **list of Identity's**. This means we can't compare `ctx.identity` to `task.project.users.user.identity` with `==` as they are different types. For this case we need to use the `in` operator to say that the authenticated Identity must be in the list of Identity's with access to the project.
+The important thing here is the **“for each”** part of the last two steps. Because a project has many users we ultimately end up with a **list of Identities**. This means we can't compare `ctx.identity` to `task.project.users.user.identity` with `==` as they are different types. For this case we need to use the `in` operator to say that the authenticated Identity must be in the list of Identity's with access to the project.
 
 ## Functions
 

--- a/pages/testing.mdx
+++ b/pages/testing.mdx
@@ -3,7 +3,7 @@ import { Callout } from 'nextra/components'
 
 Testing is built into the core of Keel. The testing package is generated from your project schema and gives full type safety for writing end-to-end tests against built-in actions, custom functions, and jobs defined in your schema.
 
-Tests run locally on your machine against a temporary database, so there are no nasty surprises when you come to deploy your schema!
+Tests run locally on your machine against a temporary Docker-based database, so there are no nasty surprises when you come to deploy your schema!
 
 ## Getting started
 


### PR DESCRIPTION
This PR fixes the docs in the following ways:

- Heavily reorganizes the functions docs to represent action functions and custom functions
- Prioritizes generated API client over endpoints
- Makes `Identity` interplay with application users clearer
- Adds many more permissions examples