### PR TITLE
Fix auth provider names and secret

### DIFF
--- a/pages/authentication/configuration.mdx
+++ b/pages/authentication/configuration.mdx
@@ -71,4 +71,4 @@ auth:
 
 This is only necessary for the [SSO Login flow](/authentication/flows/sso-login).
 
-The name of the secret has the format `KEEL_AUTH_PROVIDER_SECRET_{name}` where `{name}` is the UPPER_SNAKE_CASEd name of the provider as configured in your `keelconfig.yaml` file. See the SSO Login page for more.
+The name of the secret has the format `AUTH_PROVIDER_SECRET_{name}` where `{name}` is the UPPER_SNAKE_CASED name of the provider as configured in your `keelconfig.yaml` file. See the SSO Login page for more.

--- a/pages/authentication/configuration.mdx
+++ b/pages/authentication/configuration.mdx
@@ -47,7 +47,7 @@ No additional fields need to be provided.
 auth:
   providers:
     - type: google
-      name: 'My google client'
+      name: google_client
       clientId: hfjuwaa3a2983h1hfsdf
 ```
 

--- a/pages/authentication/flows/sso-login.mdx
+++ b/pages/authentication/flows/sso-login.mdx
@@ -76,7 +76,7 @@ auth:
   redirectUrl: http://localhost:8000/callback
   providers:
     - type: google
-      name: google
+      name: google_client
       clientId: 1234
 
 ```

--- a/pages/authentication/getting-started.mdx
+++ b/pages/authentication/getting-started.mdx
@@ -42,7 +42,7 @@ Authentication providers are all configured in your `keelconfig.yaml` file.  For
 auth:
   providers:
     - type: google
-      name: 'Google Example'
+      name: google_client
       clientId: {{clientId}}
 ```
 
@@ -52,14 +52,14 @@ If you would like to configure your own custom provider, please read the [Config
 
 If you plan to use the SSO Login flow, then you will need to configure the client secret on every host on which your Keel app will run.  
 
-Secrets for authentication providers follow this pattern: `AUTH_PROVIDER_SECRET_{provider name}` where `{{provider name}}` is a provider name written in UPPER_SNAKE_CASE. In our case, it will be `KEEL_AUTH_SECRET_GOOGLE_EXAMPLE`.
+Secrets for authentication providers follow this pattern: `AUTH_PROVIDER_SECRET_{provider name}` where `{{provider name}}` is a provider name written in UPPER_SNAKE_CASE. In our case, it will be `AUTH_PROVIDER_SECRET_GOOGLE_CLIENT`.
 
 #### Locally
 
-If you are running Keel locally, you can set the client secret by setting the environment variable `KEEL_AUTH_SECRET_GOOGLE_EXAMPLE` to the client secret you obtained from your provider. Then, you'll need to add it to your local Keel backend. You can do so by running the following command using the [Keel CLI](/cli).
+If you are running Keel locally, you can set the client secret by setting the environment variable `AUTH_PROVIDER_SECRET_GOOGLE_CLIENT` to the client secret you obtained from your provider. Then, you'll need to add it to your local Keel backend. You can do so by running the following command using the [Keel CLI](/cli).
 
 ```
-keel secrets set development KEEL_AUTH_SECRET_GOOGLE_EXAMPLE <your client secret>
+keel secrets set development AUTH_PROVIDER_SECRET_GOOGLE_CLIENT <your client secret>
 ```
 
 The `secrets` command has the following signature:
@@ -68,11 +68,11 @@ The `secrets` command has the following signature:
 keel secrets set <env> <key> <value>
 ```
 
-So here, we're setting the `KEEL_AUTH_SECRET_GOOGLE_EXAMPLE` to your secrent for the `development` environment. You can also set alternate secrets for other environments, such as `testing`.
+So here, we're setting the `AUTH_PROVIDER_SECRET_GOOGLE_CLIENT` to your secrent for the `development` environment. You can also set alternate secrets for other environments, such as `testing`.
 
 #### In Production on the Keel Console
 
-If you're hosting your app on Keel, you can set the client secret by going to the **Secrets** tab on the [Keel Console](https://console.keel.xyz), where you can find an "Add secret" button. Clicking this will give you two form fields: key and value. There, you can add `KEEL_AUTH_SECRET_GOOGLE_EXAMPLE` as the key and your client secret as the value.
+If you're hosting your app on Keel, you can set the client secret by going to the **Secrets** tab on the [Keel Console](https://console.keel.xyz), where you can find an "Add secret" button. Clicking this will give you two form fields: key and value. There, you can add `AUTH_PROVIDER_SECRET_GOOGLE_CLIENT` as the key and your client secret as the value.
 
 Every subsequent deployment will have access to this secret.
 

--- a/pages/keelconfig.mdx
+++ b/pages/keelconfig.mdx
@@ -51,7 +51,7 @@ auth:
   redirectUrl: http://localhost:8000/callback
   providers:
     - type: google
-      name: google
+      name: google_client
       clientId: 1234
 ```
 


### PR DESCRIPTION
Fixed the auth provider secret names to be `AUTH_PROVIDER_SECRET_` and fixed auth provider names in the keelconfig.yaml examples.