### PR TITLE
Fix section level markup in Quickstart in local-environment.mdx

### DIFF
--- a/pages/local-environment.mdx
+++ b/pages/local-environment.mdx
@@ -65,7 +65,7 @@ import { Tab, Tabs } from 'nextra-theme-docs'
   </Tab>
 </Tabs>
 
-### Docker
+#### Docker
 
 Docker is used by the CLI to run an instance of PostgreSQL. We only require that Docker is installed and running.  You do not need to configure it in any way, nor do you need to install PostgreSQL itself.
 


### PR DESCRIPTION
Fix level of the Docker's section. If I get it right it should be the same as nodejs.
![изображение](https://github.com/teamkeel/docs/assets/519146/e71f0cb0-604b-4f81-85bd-c9bc7df13763)
