### PR TITLE
Keel on NPM

### DIFF
--- a/pages/advanced-tutorial/setup.mdx
+++ b/pages/advanced-tutorial/setup.mdx
@@ -58,7 +58,7 @@ The Keel VS Code extension provides sytax highlighting and inline validation of 
 
 ## Installing the Keel CLI
 
-Next up, we need to install the keel CLI to our local machine, we can do this by running the following commands:
+Next up, we need to install the Keel CLI to our local machine.  We can do this by running the following command:
 
 Install the CLI globally from NPM:
 

--- a/pages/advanced-tutorial/setup.mdx
+++ b/pages/advanced-tutorial/setup.mdx
@@ -57,22 +57,20 @@ The Keel VS Code extension provides sytax highlighting and inline validation of 
 </Callout>
 
 ## Installing the Keel CLI
+
 Next up, we need to install the keel CLI to our local machine, we can do this by running the following commands:
 
-### Homebrew
-
-The easiest way to install the Keel CLI is via [Homebrew](https://brew.sh/).
+Install the CLI globally from NPM:
 
 ```bash
-$ brew tap teamkeel/homebrew-keel
-$ brew install keel
+$ npm install --global keel
 ```
 
-You can check the installation by running `keel -v` or `keel --version` in your terminal.
+If the CLI has installed correctly, the following command will respond with the current version number:
 
 ```bash
 $ keel -v
-v0.378.0
+v0.379.1
 ```
 
 <Callout type="info" emoji="💡">

--- a/pages/functions/hooks/migration-guide.mdx
+++ b/pages/functions/hooks/migration-guide.mdx
@@ -8,7 +8,7 @@ luckily migrating your schema across to use the new syntax is straightforward.
 You will need to upgrade your Keel CLI to the latest version:
 
 ```bash
-brew update && brew upgrade keel
+$ npm install --global keel
 ```
 
 ## A New Schema Keyword

--- a/pages/local-environment.mdx
+++ b/pages/local-environment.mdx
@@ -66,8 +66,6 @@ $ keel -v
 v0.379.1
 ```
 
-
-
 ## VSCode Extension
 
 <Callout type="info" emoji="ℹ️">

--- a/pages/local-environment.mdx
+++ b/pages/local-environment.mdx
@@ -1,36 +1,14 @@
 # Local environment setup
 
-
 When developing your Keel app locally there are two things which you'll probably want to setup - our CLI and our VSCode extension. Our CLI lets you run your project and develop against your APIs locally whilst our VSCode extension provides inline validation, formatting, and syntax highlighting for Keel schema files.
-
-## Install the CLI
-The easiest way to install our CLI is via [Homebrew](https://brew.sh/).
-
-```bash
-$ brew tap teamkeel/homebrew-keel
-$ brew install keel
-```
-
-You can check the installation by running `keel -v` or `keel --version` in your terminal.
-
-```bash
-$ keel -v
-v0.378.0
-```
-
-import { Callout } from 'nextra/components'
-
-<Callout type="info" emoji="ℹ️">
-  In the future we'll support other installation methods for the CLI (such as npm) and also platforms other than Mac.
-  In the interim, linux users can install the CLI via Homebrew, and Windows users can do the same via [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
-</Callout>
 
 ### Dependencies
 
 You will need to install the following dependencies in order to use the Keel CLI locally:
 
 #### Node.js
-Node.js is used for running your functions and tests. We require Node version 18 or higher.
+
+Node.js is used for running your functions and tests, and NPM is required to install Keel.  We require Node version 18 or higher.
 
 import { Tab, Tabs } from 'nextra-theme-docs'
 
@@ -72,6 +50,23 @@ Docker is used by the CLI to run an instance of PostgreSQL. We only require that
 There are a few ways to get Docker installed and running on your local machine, however Docker Desktop is the easiest way to get started. Follow the [installation instructions for Docker Desktop](https://docs.docker.com/desktop/) to get set up.
 
 Please also make sure that Docker is running. You can test this by running `docker ps` in your terminal. 
+
+## Install the CLI
+
+Install the CLI globally:
+
+```bash
+$ npm install --global keel
+```
+
+If the CLI has installed correctly, the following command will respond with the current version number:
+
+```bash
+$ keel -v
+v0.379.1
+```
+
+
 
 ## VSCode Extension
 

--- a/pages/local-environment.mdx
+++ b/pages/local-environment.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 # Local environment setup
 
 When developing your Keel app locally there are two things which you'll probably want to setup - our CLI and our VSCode extension. Our CLI lets you run your project and develop against your APIs locally whilst our VSCode extension provides inline validation, formatting, and syntax highlighting for Keel schema files.
@@ -53,13 +55,13 @@ Please also make sure that Docker is running. You can test this by running `dock
 
 ## Install the CLI
 
-Install the CLI globally:
+Install the CLI globally from [NPM](https://www.npmjs.com/package/keel).
 
 ```bash
 $ npm install --global keel
 ```
 
-If the CLI has installed correctly, the following command will respond with the current version number:
+If the CLI has installed correctly, the following command will respond with the current version number.
 
 ```bash
 $ keel -v

--- a/pages/quickstart.mdx
+++ b/pages/quickstart.mdx
@@ -20,8 +20,7 @@ Since Keel applications are described in a custom schema language, we have a [VS
 To get the most out of Keel, you'll need the [Keel CLI](/cli) that can be installed by running the following command in your terminal:
 
 ```sh
-brew tap teamkeel/homebrew-keel
-brew install keel
+$ npm install --global keel
 ```
 
 This CLI will set you up with everything you need to run Keel locally before deploying to production.

--- a/pages/release-notes/0.365.mdx
+++ b/pages/release-notes/0.365.mdx
@@ -41,14 +41,6 @@ We now have full support for OIDC external provides which changes the behaviour 
 ## Bug Fixes
 - Fixed a bug in the Keel schema validation process that is causing the Keel validate and Keel run to throw a nil pointer error.
 
-## Next Steps
-
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 Read the [Migration Guide for Hooks](/functions/hooks/migration-guide)
 
 For any issues or feedback, please visit the support channel on our community discord or contact us at [help@keel.so](mailto:help@keel.so).

--- a/pages/release-notes/0.368.mdx
+++ b/pages/release-notes/0.368.mdx
@@ -12,14 +12,6 @@ With events you are able to asynchronously execute a subscriber function at the 
 
 Go to the [Events](/events) page in our documentation to get started.
 
-## Next Steps
-
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 For any issues or feedback, please visit the support channel on our community discord or contact us at [help@keel.so](mailto:help@keel.so).
 
 Thank you for using Keel!

--- a/pages/release-notes/0.369.mdx
+++ b/pages/release-notes/0.369.mdx
@@ -52,14 +52,6 @@ We are excited to announce the release of Keel `0.369`. This update brings some 
 - Removed the **`keel version`** command.
 - Introduced **`keel -v`** or **`keel --version`** as a replacement.
 
-## Next Steps
-
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 For any issues or feedback, please visit the support channel on our [community discord](https://keel.so/discord) or contact us at [help@keel.so](mailto:help@keel.so)**.**
 
 Thank you for using Keel!

--- a/pages/release-notes/0.370.mdx
+++ b/pages/release-notes/0.370.mdx
@@ -65,9 +65,6 @@ model Product {
  - `keel generate` will politely amend, rather than overwrite, the `tsconfig.json` file if it exists.
  - General improvements to how we pipe output to the terminal when running `keel test` and `keel generate`.
 
-
-## Next Steps
-
 For any issues or feedback, please visit the support channel on our [community discord](https://keel.so/discord) or contact us at [help@keel.so](mailto:help@keel.so)**.**
 
 Thank you for using Keel!

--- a/pages/release-notes/0.370.mdx
+++ b/pages/release-notes/0.370.mdx
@@ -68,12 +68,6 @@ model Product {
 
 ## Next Steps
 
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 For any issues or feedback, please visit the support channel on our [community discord](https://keel.so/discord) or contact us at [help@keel.so](mailto:help@keel.so)**.**
 
 Thank you for using Keel!

--- a/pages/release-notes/0.371.mdx
+++ b/pages/release-notes/0.371.mdx
@@ -36,14 +36,6 @@ Take a visit over at [the official documentation](/jobs) to learn more.
 
 We've also released [a bunch of fixes and improvements](https://github.com/teamkeel/keel/releases/tag/v0.371.0) to our CLI, the SDK packages, and to our VS Code extension. And, in case you missed it, we did a [patch release](https://github.com/teamkeel/keel/releases/tag/v0.370.1) last week, which shipped with some major improvements to our runtime.
 
-## Next Steps
-
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 For any issues or feedback, please visit the support channel on our [community discord](https://keel.so/discord) or contact us at [help@keel.so](mailto:help@keel.so)**.**
 
 Thank you for using Keel!

--- a/pages/release-notes/0.372.mdx
+++ b/pages/release-notes/0.372.mdx
@@ -60,14 +60,6 @@ Today we have shipped a pre-release of **OIDC Token authentication**.  With this
 
 We've also released [a bunch of fixes and improvements](https://github.com/teamkeel/keel/releases/tag/v0.372.0) to our CLI, the SDK packages, and to our VS Code extension. 
 
-## Next Steps
-
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 For any issues or feedback, please visit the support channel on our [community discord](https://keel.so/discord) or contact us at [help@keel.so](mailto:help@keel.so)**.**
 
 Thank you for using Keel!

--- a/pages/release-notes/0.373.mdx
+++ b/pages/release-notes/0.373.mdx
@@ -60,14 +60,6 @@ With this flow, Keel provides an abstraction over all the complex OAuth gymnasti
 
 We've also released [a bunch of fixes and improvements](https://github.com/teamkeel/keel/releases/tag/v0.373.0) to our CLI and the SDK packages, and to our VS Code extension. 
 
-## Next Steps
-
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 For any issues or feedback, please visit the support channel on our [community discord](https://keel.so/discord) or contact us at [help@keel.so](mailto:help@keel.so)**.**
 
 Thank you for using Keel!

--- a/pages/release-notes/0.374.mdx
+++ b/pages/release-notes/0.374.mdx
@@ -56,14 +56,6 @@ The following API request will now create both the author and the linked book re
 
 We've also released [a bunch of fixes and improvements](https://github.com/teamkeel/keel/releases/tag/v0.374.0) to our CLI and to our VS Code extension. 
 
-## Next Steps
-
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 For any issues or feedback, please visit the support channel on our [community discord](https://keel.so/discord) or contact us at [help@keel.so](mailto:help@keel.so)**.**
 
 Thank you for using Keel!

--- a/pages/release-notes/0.376.mdx
+++ b/pages/release-notes/0.376.mdx
@@ -18,14 +18,6 @@ And it's _really_ easy.  Run your local Keel project with `keel run`, go to [htt
 
 We've also released [a bunch of fixes and improvements](https://github.com/teamkeel/keel/releases/tag/v0.376.0) to our CLI and to our VS Code extension. 
 
-## Next Steps
-
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 For any issues or feedback, please visit the support channel on our [community discord](https://keel.so/discord) or contact us at [help@keel.so](mailto:help@keel.so)**.**
 
 Thank you for using Keel!

--- a/pages/release-notes/0.378.mdx
+++ b/pages/release-notes/0.378.mdx
@@ -30,14 +30,6 @@ We've also released [some other fixes and improvements](https://github.com/teamk
 
 Until now, we have supported passing in an OpenID Connect ID Token as a bearer token when making a request to your Keel API. We will be deprecating this change on 16 February. Please migrate to using [ID Token authentication](/authentication/getting-started).
 
-## Next Steps
-
-To upgrade to the latest version, please run the following command:
-
-```bash
-brew upgrade keel
-```
-
 For any issues or feedback, please visit the support channel on our [community discord](https://keel.so/discord) or contact us at [help@keel.so](mailto:help@keel.so)**.**
 
 Thank you for using Keel!


### PR DESCRIPTION
The Keel CLI is now available on NPM:  https://www.npmjs.com/package/keel

This PR replaces the Homebrew installation instructions.