### PR TITLE
Added create_if_not_exists and identity_created to token endpoint spec

### DIFF
--- a/pages/authentication/endpoints.mdx
+++ b/pages/authentication/endpoints.mdx
@@ -50,6 +50,7 @@ curl --request POST \
 | `code`  | Only required for `authorization_code` grant   |
 | `username`  | Only required for `password` grant   |
 | `password`  | Only required for `password` grant   |
+| `create_if_not_exists` | To create the identity or not during `token_exchange` or `password` flow. Default is `true`. |
 
 We currently support four types of _grants_:
 
@@ -67,7 +68,8 @@ Regardless of the grant request, a successful response will return with a `appli
   "access_token": "{{keel_access_token}}",
   "token_type": "Bearer",
   "expires_in": 86400,
-  "refresh_token": "{{keel_refresh_token}}"
+  "refresh_token": "{{keel_refresh_token}}",
+  "identity_created": true
 }
 ```
 

--- a/pages/authentication/flows/id-token.mdx
+++ b/pages/authentication/flows/id-token.mdx
@@ -75,7 +75,8 @@ If you are successfully authenticated, the token endpoint will respond with `HTT
   "access_token": "{{keel_access_token}}",
   "token_type": "Bearer",
   "expires_in": 86400,
-  "refresh_token": "{{keel_refresh_token}}"
+  "refresh_token": "{{keel_refresh_token}}",
+  "identity_created": false
 }
 ```
 

--- a/pages/authentication/flows/password.mdx
+++ b/pages/authentication/flows/password.mdx
@@ -47,7 +47,8 @@ If you are successfully authenticated, the token endpoint will respond with `HTT
   "access_token": "{{keel_access_token}}",
   "token_type": "Bearer",
   "expires_in": 86400,
-  "refresh_token": "{{keel_refresh_token}}"
+  "refresh_token": "{{keel_refresh_token}}",
+  "identity_created": false
 }
 ```
 

--- a/pages/authentication/flows/sso.mdx
+++ b/pages/authentication/flows/sso.mdx
@@ -105,7 +105,8 @@ The expected `Content-Type` of the `/auth/token` endpoint is `application/x-www-
   "access_token": "{{keel_access_token}}",
   "token_type": "Bearer",
   "expires_in": 86400, // one day
-  "refresh_token": "{{keel_refresh_token}}"
+  "refresh_token": "{{keel_refresh_token}}",
+  "identity_created": false
 }
 ```
 

--- a/pages/authentication/tokens.mdx
+++ b/pages/authentication/tokens.mdx
@@ -9,7 +9,8 @@ When an username/password, ID token or authorization code is exchanged for a set
   "access_token": "{{access_token}}",
   "token_type": "Bearer",
   "expires_in": 86400,
-  "refresh_token": "{{refresh_token}}"
+  "refresh_token": "{{refresh_token}}",
+  "identity_created": false
 }
 ```
 
@@ -75,7 +76,8 @@ If the refresh token is still valid, then a new access token will be minted and 
   "access_token": "{{keel_access_token}}",
   "token_type": "Bearer",
   "expires_in": 86400,
-  "refresh_token": "{{keel_id_token}}"
+  "refresh_token": "{{keel_id_token}}",
+  "identity_created": false
 }
 ```
 

--- a/pages/quickstart.mdx
+++ b/pages/quickstart.mdx
@@ -179,7 +179,8 @@ If all went well, we should receive a response that looks something like this:
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrZWVsIiwic3ViIjoiMll0ckZPdnFjQmQyZzFKRFQzOE9WQW9qWmMxIiwiZXhwIjoxNzAxNDQyMDEyLCJpYXQiOjE3MDEzNTU2MTJ9.bFBsXXJIaVy4ELRKInBKKQoFEVtAwJ1DUNH9oCwo0aT-5r5lQA6kEXJUrDK35Ini-0rKJfahwz-FcOQ6uLToIxuvoWeTtCLvVjEeBVcJWvpEASxXfntnIvn3oZBOhR8icExbPecbKE0dMmxRxvWmrjr3XDD9gUeWpj1MO4ihCgCszHRFJRjcMdy-3QzQ81LZXn0_SeXVpMgdfKIx7HLR95B2mnQi45isNreg9_lpzpXNIzH6r6YAmgamEmZIBts7e908VI2GeMEgB_ebgr2nN5s9R7X1rOSuXs31dB7LBsJgf2xYJ8KkF8O4SUV3rVZl1smJeBUsuMS6aWvy6cnwkQ",
   "token_type": "Bearer",
   "expires_in": 86400,
-  "refresh_token": "Nw6KK5wZ3KwEusohLJoW4ZXi2MMeKSWkOEIiyOjo3p3QbvGmdzi2Amr92OSZANo8"
+  "refresh_token": "Nw6KK5wZ3KwEusohLJoW4ZXi2MMeKSWkOEIiyOjo3p3QbvGmdzi2Amr92OSZANo8",
+  "identity_created": false
 }
 ```
 


### PR DESCRIPTION
Changes to the token endpoint are:
 - New input parameter `create_if_not_exists` (for password and ID token flows)
 - New response parameter `identity_created`