### PR TITLE
Previous model payment in subscriber event payload

### DIFF
--- a/pages/events.mdx
+++ b/pages/events.mdx
@@ -82,6 +82,8 @@ export interface MemberCreatedEvent = {
      type: "Member",
      // The model's data at the time of the event
      data: Member
+     // The model's data before the mutation which caused this event
+     previous: Member
   }
 }
 ```
@@ -91,6 +93,8 @@ The `event.target.data` property provides the full model's data to the subscribe
  - `create` - provides the newly persisted model
  - `update` - provides the persisted model after it has been updated
  - `delete` - provides the model at the time it was deleted
+
+The `event.target.previous` property provides the full model's data before the mutation which caused the event. This is only available on `update` and `delete` event types.
 
 ### Discerning between events
 


### PR DESCRIPTION
The event payload for update and delete events types now include the full state of the model before the mutation which triggered the event.

See https://github.com/teamkeel/keel/pull/1456