### PR TITLE
fix typo in events.mdx

### DIFF
--- a/pages/events.mdx
+++ b/pages/events.mdx
@@ -116,7 +116,7 @@ export default VerifyEmail(async (ctx, event) => {
 
     case "member.updated":
       // Verify their email address if it was changed.
-      if (!event.data.emailVerified) {
+      if (!event.target.data.emailVerified) {
         await sendVerifyMail(event.target.email);
       }
       break;

--- a/pages/events.mdx
+++ b/pages/events.mdx
@@ -116,7 +116,7 @@ export default VerifyEmail(async (ctx, event) => {
 
     case "member.updated":
       // Verify their email address if it was changed.
-      if (!member.emailVerified) {
+      if (!event.data.emailVerified) {
         await sendVerifyMail(event.target.email);
       }
       break;


### PR DESCRIPTION
not sure if I'm making the correct suggestion, but the original code cannot possibly work because there is no `member` variable.