### PR TITLE
Add Duration field type documentation

### DIFF
--- a/pages/functions/sdk/modelApi.mdx
+++ b/pages/functions/sdk/modelApi.mdx
@@ -212,3 +212,73 @@ export default CreatePost({
   }
 });
 ```
+
+## Rich Data Types
+
+The SDK also provides class implementation for certain field types. These further simplify the interaction with these rich data types:
+
+| Field Type | Description | SDK Class |
+|------------|-------------|-----------|
+| `Duration` | A time interval (ISO 8601 format) | `Duration` |
+| `File` | A file input, supplied as a data URL | `File` and `InlineFile` |
+
+
+### `Duration`
+
+This class provides utility methods for working with durations, such as:
+
+* `Duration.fromISOString(s)`: Static constructor used to create an instance of `Duration`.
+* `toISOString()`: Converts the duration to an ISO 8601 string.
+* `toPostgres()`: Converts the duration to PostgreSQL's interval format.
+
+
+Creating and retrieving records with durations:
+
+```ts
+import { WriteCustomFunction, models, Duration } from "@teamkeel/sdk";
+
+export default WriteCustomFunction(async (ctx, inputs) => {
+  const post = await models.post.create({ readTime: Duration.fromISOString("PT1H") });
+  const readPost = await models.post.findOne({ id: post.id });
+  return {
+    readTime: readPost.readTime.toISOString(),
+  };
+});
+```
+
+When using a duration field as an input to a custom function, the input will automatically be an instance of the `Duration` class:
+
+```keel
+message DurationInput {
+    duration Duration
+}
+```
+
+```ts
+export default DurationInputFunction(async (ctx, inputs) => {
+  console.log(inputs.duration.toISOString());
+
+  const post = await models.post.create({ readTime: inputs.duration });
+  return {
+    readTime: post.readTime.toISOString(),
+  };
+});
+```
+
+<Callout type="info">
+  Duration fields are also returned as an instance of the `Duration` class when using the query builder:
+  ```ts
+  const posts = await useDatabase()
+  .selectFrom("posts")
+  .selectAll()
+  .execute();
+
+  return {
+    readTime: posts[0].readTime.toISOString()
+  };
+  ```
+</Callout>
+
+### `File` and `InlineFile`
+
+Keel provides a `File` TypeScript class in the functions runtime and full support for reading and writing files, which means that they can be used in `read` and `write` [custom functions](/functions/custom-functions), [action hooks](/functions/action-hooks), [jobs](/jobs) and [subscriber functions](/events). For more information please refer to the [Files](/files) documentation.

--- a/pages/models.mdx
+++ b/pages/models.mdx
@@ -38,6 +38,7 @@ The built-in Keel types are:
 - `Boolean` - a true or false value
 - `Timestamp` - a date time accurate to a microsecond
 - `Date` - a date, with no time
+- `Duration` - a time interval, formatted as an [ISO8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) string e.g. `P3DT4H5M6S`
 - `ID` - basically the same as `Text` but indicates the value is used to identify *something*
 - `File` - a file that can be passed inline with the API requests as a data URL. For more information see [Files](/files).
 

--- a/pages/schema-reference.mdx
+++ b/pages/schema-reference.mdx
@@ -59,6 +59,7 @@ Built-in scalar types:
 | `Number` | An integer |
 | `Decimal` | A decimal number |
 | `Date` | A date without time (ISO 8601 format) |
+| `Duration` | A time interval (ISO 8601 format) |
 | `Timestamp` | A UTC timestamp |
 | `Boolean` | A boolean value (`true` or `false`) |
 | `Secret` | An encrypted secret |


### PR DESCRIPTION
Adding docs for the new `Duration` field type with example usage in a ModelAPI/custom functions environment